### PR TITLE
gcc: add ldd at end of build

### DIFF
--- a/core/gcc/build
+++ b/core/gcc/build
@@ -41,6 +41,9 @@ export libat_cv_have_ifunc=no
 make
 make DESTDIR="$1" install
 
+# add ldd, which in musl is baked into the .so
+ln -sf ../lib/ld-musl-x86_64.so.1 "$1"/bin/ldd
+
 # Save 35MB.
 find "$1" -name libgtkpeer.a  -delete
 find "$1" -name libgjsmalsa.a -delete


### PR DESCRIPTION
the `ldd` command in musl is not a binary but rather a symlink to the .so

noticed you didn't have this in your gcc build, perhaps its elsewhere?

edit: i dont actually have kiss installed, so check that your .so is named as it is in the PR before accepting (`../lib/ld-musl-x86_64.so.1`)