### PR TITLE
Various packages: Build with cc instead of gcc (part 2)

### DIFF
--- a/core/baseinit/build
+++ b/core/baseinit/build
@@ -7,4 +7,4 @@ cp -R lib "$1/usr/lib"
 
 # Disable warning as CFLAGS must work this way.
 # shellcheck disable=2086
-"${CC:-gcc}" -o "$1/usr/bin/kpow" bin/kpow.c $CFLAGS -static
+"${CC:-cc}" -o "$1/usr/bin/kpow" bin/kpow.c $CFLAGS -static

--- a/core/mandoc/build
+++ b/core/mandoc/build
@@ -11,7 +11,7 @@ PREFIX=/usr
 MANDIR=/usr/share/man
 LIBDIR=/usr/lib
 SBINDIR=/usr/bin
-CC="${CC:-gcc}"
+CC="${CC:-cc}"
 CFLAGS="$CFLAGS"
 LN="ln -sf"
 EOF


### PR DESCRIPTION
Looks like I overlooked a few packages from #147.