### PR TITLE
ffmpeg: change the way $CC and $CXX is set

### DIFF
--- a/extra/ffmpeg/build
+++ b/extra/ffmpeg/build
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 
 ./configure \
+    --cc="${CC:-cc}" \
+    --cxx="${CXX:-c++}" \
     --prefix=/usr \
     --enable-shared \
     --enable-gpl \
@@ -18,7 +20,7 @@
     --enable-libdrm \
     --disable-debug
 
-make CC="${CC:-cc}"
+make
 make DESTDIR="$1" install
 
 # Remove examples.


### PR DESCRIPTION
Turns out `ffmpeg` was detecting `$CC` and `$CXX` from its `./configure` script.