### PR TITLE
xf86-video-intel: switch to meson

### DIFF
--- a/xorg/xf86-video-intel/build
+++ b/xorg/xf86-video-intel/build
@@ -1,16 +1,18 @@
 #!/bin/sh -e
 
 export LDFLAGS="-Wl,-z,lazy"
+export DESTDIR="$1"
 
 # Fix build fail with GCC 10.
 export CFLAGS="$CFLAGS -fcommon"
 
-autoreconf -i
-
-./configure \
+meson \
     --prefix=/usr \
     --libexecdir=/usr/lib \
-    --with-default-dri=3
+    -Ddefault-dri=3 \
+    -Dxvmc=false \
+    -Dvalgrind=false \
+    . build
 
-make
-make DESTDIR="$1" install
+ninja -C build
+ninja -C build install

--- a/xorg/xf86-video-intel/depends
+++ b/xorg/xf86-video-intel/depends
@@ -1,9 +1,9 @@
-autoconf make
-automake make
 libXScrnSaver
 libXcursor
 libXinerama
 libXrandr
+libXtst
 libdrm
 libpciaccess
-libtool make
+meson make
+xorg-server


### PR DESCRIPTION
## Rationale

While building `xf86-video-intel` I'm actually surprised they don't have a pre-generated `./configure`, and building `autoconf`, `automake`, and `libtool` just to get it running are overkill and makes builds "bloaty" (assuming one doesn't use `eiwd`).

This switches the build to use `meson` instead. Since it's already used by some packages needed by `xorg-server` (namely, `mesa`), this should be fine.

And yes, the dependency add is necessary.