### PR TITLE
glib requires libelf.

### DIFF
--- a/extra/glib/depends
+++ b/extra/glib/depends
@@ -1,3 +1,4 @@
+libelf
 libffi
 meson make
 zlib


### PR DESCRIPTION
Since libelf is no longer in core, glib fails to build unless libelf is installed.