### PR TITLE
firefox-bin: fix package naming issue

### DIFF
--- a/extra/firefox-bin/build
+++ b/extra/firefox-bin/build
@@ -13,7 +13,7 @@ printf 'Installing firefox-bin\n'
 # The tarball is hosted on GitHub which doesn't allow
 # for the file naming scheme the package manager uses
 # for its built tarballs (pkg#ver-rel.tar.gz).
-mv -f firefox*\?no-extract "firefox#68.6.0esr-3.tar.gz"
+mv -f firefox*\?no-extract "firefox-bin#68.6.0esr-3.tar.gz"
 
 # Install the package as you would any other you have
 # built yourself. In reality, I could have just given
@@ -22,7 +22,7 @@ mv -f firefox*\?no-extract "firefox#68.6.0esr-3.tar.gz"
 #
 # I'm nice though and want this to fit into the system
 # like any other package.
-KISS_FORCE=1 kiss i "$PWD/firefox#68.6.0esr-3.tar.gz"
+KISS_FORCE=1 kiss i "$PWD/firefox-bin#68.6.0esr-3.tar.gz"
 
 cat <<EOF
 


### PR DESCRIPTION
Fixes part of [this](https://github.com/kisslinux/kiss/issues/125) issue.