### PR TITLE
firefox, firefox-esr: use cc instead of gcc by default

### DIFF
--- a/extra/firefox-esr/build
+++ b/extra/firefox-esr/build
@@ -36,8 +36,8 @@ cd build
 
 # Bypass 'ccache' as it's totally useless when building
 # Firefox and only slows things down.
-export CC="${CC:-/usr/bin/gcc}"
-export CXX="${CXX:-/usr/bin/g++}"
+export CC="${CC:-/usr/bin/cc}"
+export CXX="${CXX:-/usr/bin/c++}"
 
 export LDFLAGS="$LDFLAGS -Wl,-rpath=/usr/lib/firefox"
 export RUSTFLAGS="$RUSTFLAGS -Cdebuginfo=0"

--- a/extra/firefox/build
+++ b/extra/firefox/build
@@ -35,8 +35,8 @@ cd build
 
 # Bypass 'ccache' as it's totally useless when building
 # Firefox and only slows things down.
-export CC="${CC:-/usr/bin/gcc}"
-export CXX="${CXX:-/usr/bin/g++}"
+export CC="${CC:-/usr/bin/cc}"
+export CXX="${CXX:-/usr/bin/c++}"
 
 export LDFLAGS="$LDFLAGS -Wl,-rpath=/usr/lib/firefox"
 export RUSTFLAGS="$RUSTFLAGS -Cdebuginfo=0"


### PR DESCRIPTION
Same spirit as #147. As a lot of Wyverkiss' changes related to autoconf+GNU m4 hullabaloo and not a compiler-related change.