### PR TITLE
libelf: assume that compiler supports gnu99

### DIFF
--- a/extra/libelf/build
+++ b/extra/libelf/build
@@ -11,11 +11,13 @@ sed -i 's/as_fn_error.*libargp/: "/g' configure
 # Don't compile two unrelated C files which require argp.
 sed -i 's/color.*printversion../#/g' lib/Makefile.in
 
+# Override C99 check for Clang.
 ./configure \
     --prefix=/usr \
     --disable-symbol-versioning \
     --disable-debuginfod \
-    --disable-nls
+    --disable-nls \
+    ac_cv_c99=yes
 
 # Skip the default make target and build only what we need.
 make -C lib


### PR DESCRIPTION
For several days I've been contemplating whether to upstream this or not, and *which* part to upstream. Since `clang` is available on `extra` (so it's possible to use `CC=clang`), and `elfutils` is the only package that cannot be built with clang, I decided to make this PR. With `ac_cv_c99=yes`, we bypass the extra check added in by elfutils devs since the only part we need (libelf) can be built on clang (and as @dilyn-corner and I tested, they're fine).

I also thought about upstreaming https://github.com/konimex/kiss-llvm/blob/ba7b142c5058898bd9fca163e1e64e809fd73b2a/libelf/build#L9 just to "clean" the warnings for a bit, but decided against it since we add `-Wno-error` and the change is purely cosmetic.