### PR TITLE
binutils: add --enable-deterministic-archives as default build option

### DIFF
--- a/core/binutils/build
+++ b/core/binutils/build
@@ -23,7 +23,8 @@ export PATH=$PATH:$PWD
     --disable-readline \
     --disable-gprof \
     --with-mmap \
-    --with-system-zlib
+    --with-system-zlib \
+    --enable-deterministic-archives
 
 make configure-host
 make tooldir=/usr


### PR DESCRIPTION
Turn on deterministic mode for `binutils` which will use zero for UIDs, GIDs, timestamps and use consistent file modes for all files.

This will ensure the resulting `.a` archive files can be reproducible across builds. This can be useful for users who wish to verify the output of different builds (ensure the `shasum`s are identical).

Debian has had this enabled since version 2.25-6 [1] and FreeBSD since 2015 [2] with no issues.

Some further justification,
> Ar cannot handle UIDs with more than 6 digits, and there's little value in storing the mtime, uid, gid and mode anyhow. Turn on deterministic (-D) mode by default; it can be disabled by the user with -U.

[1] - https://wiki.debian.org/ReproducibleBuilds/TimestampsInStaticLibraries
[2] - https://reviews.freebsd.org/D3190
