### PR TITLE
gtk+3: remove '--enable-debug=no' flag

### DIFF
--- a/extra/gtk+3/build
+++ b/extra/gtk+3/build
@@ -22,7 +22,6 @@ sed -i 's/docs m4macros/m4macros/'          Makefile.am Makefile.in
     --enable-xcomposite \
     --enable-xdamage \
     --enable-x11-backend \
-    --enable-debug=no \
     --disable-schemas-compile \
     --disable-cups \
     --disable-papi \


### PR DESCRIPTION
From https://developer.gnome.org/gtk3/stable/gtk-building.html#extra-configuration-options

> --enable-debug.  Turns on various amounts of debugging support. Setting this to 'no' disables g_assert(), g_return_if_fail(), g_return_val_if_fail() and all cast checks between different object types. Setting it to 'minimum' disables only cast checks. Setting it to 'yes' enables runtime debugging. The default is 'minimum'. Note that 'no' is fast, but dangerous as it tends to destabilize even mostly bug-free software by changing the effect of many bugs from simple warnings into fatal crashes. Thus --enable-debug=no should not be used for stable releases of GTK+

Was causing a segfault in chromium when trying to use GTK theme.