### PR TITLE
libvpx: make it cc-neutral

### DIFF
--- a/extra/libvpx/build
+++ b/extra/libvpx/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+export CC="${CC:-cc}"
+export CXX="${CXX:-c++}"
+
 patch -p1 < fix-busybox-diff.patch
 
 # Remove the perl requirement from configure
@@ -13,6 +16,7 @@ sed -i 's/perl/:/g' configure
     --enable-vp9 \
     --enable-experimental \
     --enable-runtime-cpu-detect \
+    --target=x86_64-linux-gcc \
     --enable-shared \
     --enable-postproc \
     --enable-pic \


### PR DESCRIPTION
Self-explanatory.

The reason we need `--target=x86_64-linux-gcc` flag is because the way they detect things in `./configure`, if the flag is added and `cc` is detected but not `gcc`, it seems they'll generate a generic header (which doesn't use the x86_64-specific flags) and will not use KISS-generated ones. Since KISS only supports x86_64, adding this flag should not be a problem.