### PR TITLE
various wayland packages: fix build with clang

### DIFF
--- a/wayland/libinput/build
+++ b/wayland/libinput/build
@@ -4,6 +4,11 @@ patch -p1 < evdev-wrap.patch
 
 export CFLAGS="$CFLAGS -fPIC"
 
+# Clang reports error because of -Werror, using the CFLAGS below since
+# in some cases, it's unused. Force -Wno-error in this case.
+sed 's/Werror-Wno-error/' meson.build > _
+mv -f _ meson.build
+
 for pkg in mtdev evdev; do (
     cd "$pkg"
 

--- a/wayland/libseat/build
+++ b/wayland/libseat/build
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 export DESTDIR="$1"
+export CFLAGS="$CFLAGS -Wno-error"
 
 meson \
     --prefix=/usr \

--- a/wayland/sway-no-seat/build
+++ b/wayland/sway-no-seat/build
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+export CFLAGS="$CFLAGS -Wno-error"
+
 patch -p1 < sway-static.patch
 patch -p1 < no-evdev.patch
 


### PR DESCRIPTION
The 20210711a blog post contains a certain point that is most welcome. However, I don't know to which extent LLVM/Clang-related patches will be accepted.

- Will patches be accepted for Clang-related *only*?
- or will patches for standalone toolchain utilities (like `lld`) be accepted as well (we have the zlib precedent so this might not be too far-fetched)?
- or will patches for LLVM libraries (e.g. libc++, libunwind, compiler-rt, let's just say a full kiss-llvm (not Wyverkiss, different beast) environment with gcc and its libs removed) be accepted as well (since this may require some heavy changes, I've refrained from bringing this upstream for now)?

Also, which kind of patches? It's already demonstrated that a sed call or an additional CFLAGS is good enough to be accepted, but what if it involves a full blown patch file?

Therefore, I'm going to send easy sed-related patches for Clang first. This fixes libinput (http://termbin.com/qjuz) and sway-no-seat (http://termbin.com/oapi).

For libinput, a sed call is needed since from the logs, the build system forces `-Werror` even if `-Wno-error` CFLAGS exist.