### PR TITLE
Even more LLVM-related changes

### DIFF
--- a/extra/firefox/build
+++ b/extra/firefox/build
@@ -50,6 +50,11 @@ export MACH_USE_SYSTEM_PYTHON=1
 export MOZ_DEBUG_FLAGS=-g0
 export MOZ_NOSPAM=1
 
+# If using libc++, CXXSTDLIB will need to be set manually.
+case "$(${CC:-cc} -print-file-name=libc++.so)" in /usr/bin*)
+    export CXXSTDLIB=c++
+esac
+
 cat > .mozconfig << EOF
 ac_add_options --enable-default-toolkit=cairo-gtk3-wayland
 ac_add_options --prefix=/usr

--- a/extra/nodejs/build
+++ b/extra/nodejs/build
@@ -1,6 +1,13 @@
 #!/bin/sh -e
 
-./configure \
+[ -r /usr/lib/libatomic.so ] || (
+    sed "s/\\'libraries\\'\\: \\[\\'-latomic\\'\\],/#/g" node.gyp > _
+    mv -f _ node.gyp
+)
+
+CC="${CC:-cc}" CXX="${CXX:-c++}" \
+    ./configure \
+    --prefix=/usr \
     --shared-zlib \
     --shared-openssl \
     --with-intl=none \
@@ -9,7 +16,6 @@
     --without-report \
     --without-node-snapshot \
     --without-node-code-cache \
-    --partly-static \
     --ninja
 
 ninja -C out/Release

--- a/extra/plzip/build
+++ b/extra/plzip/build
@@ -5,6 +5,10 @@
 # compile plzip.
 (cd lzlib; ./configure; make)
 
+case "$(${CC:-cc} -print-file-name=libc++.a)" in
+    /usr/bin*) CXXFLAGS="$CXXFLAGS -lunwind -lc++abi"
+esac
+
 ./configure \
     --prefix=/usr \
     CXXFLAGS="$CXXFLAGS -static -L$PWD/lzlib -I$PWD/lzlib"


### PR DESCRIPTION
So these changes would allow even more packages to be built with the `kiss-llvm` toolchain stack without user intervention. (One last package needed will be Rust, but I'll wait until 1.54.0 so certain patches won't be needed)

I simply use a quick-and-dirty work, but I'm sure you have a better way of detecting if something exists. (`-print-file-name` would print the full path if file exist, but a `[` call should work too)

Anyway, onto rationale:

1. Since Firefox by default uses libstdc++, a special variable will be needed if libc++ (and only libc++) exist.
2. NodeJS expects libatomic by default, on kiss-llvm compiler-rt provides this and doesn't require additional flags.
3. Building plzip statically requires those two CXXFLAGS.