### PR TITLE
Removing redundant NO_SVN_TESTS option

### DIFF
--- a/core/git/build
+++ b/core/git/build
@@ -4,7 +4,6 @@ export CFLAGS="$CFLAGS -static"
 
 cat > config.mak <<EOF
 NO_GETTEXT=YesPlease
-NO_SVN_TESTS=YesPlease
 NO_TCLTK=YesPlease
 NO_EXPAT=YesPlease
 NO_NSEC=YesPlease


### PR DESCRIPTION
`NO_SVN_TESTS=YesPlease` is defined twice in `config.mak`