### PR TITLE
rust: enable build on LLVM-only systems

### DIFF
--- a/extra/rust/build
+++ b/extra/rust/build
@@ -59,11 +59,32 @@ jemalloc          = false
 debug-assertions  = false
 codegen-tests     = false
 codegen-units-std = 1
+EOF
 
+case $("$CC" -print-file-name=libunwind.so) in */*)
+cat >> config.toml <<EOF
+llvm-libunwind    = "system"
+EOF
+esac
+
+cat >> config.toml <<EOF
 [target.x86_64-unknown-linux-musl]
 llvm-config = "/usr/bin/llvm-config"
 crt-static  = false
 EOF
+
+# Since libgcc_s.so is needed for Rust's own bootstrap binary, and
+# it's dynamically linked, we'll have to add two files, libgcc_s.so.1
+# for the symlink, and libgcc_s.so so the linker points to libunwind.
+case $("$CC" -print-file-name=libunwind.so) in */*)
+    mkdir -p libgcc
+    ln -sf /usr/lib/libunwind.so.1 libgcc/libgcc_s.so.1
+    cat > libgcc/libgcc_s.so <<EOF
+INPUT(-lunwind)
+EOF
+    export LD_LIBRARY_PATH="$PWD/libgcc:$LD_LIBRARY_PATH"
+    export LIBRARY_PATH="$PWD/libgcc:$LIBRARY_PATH"
+esac
 
 python3 ./x.py build -j "$(nproc)"
 python3 ./x.py install
@@ -73,4 +94,3 @@ rm -rf \
     "$1/usr/share/doc" \
     "$1/usr/share/zsh" \
     "$1/usr/lib/rustlib/uninstall.sh"
-


### PR DESCRIPTION
Since this is one hell of a hack (i.e. worse than the last patches I sent related to these things), I decided to wait until 1.54.0 since https://github.com/rust-lang/rust/pull/84124 finally landed (and in kiss-llvm and Wyverkiss, `rust` is now patch-less).

Anyway, the most obvious things, of course, is setting `llvm-libunwind = "system"` since the default is `no` for dynamic linking to `libgcc_s.so` (and we don't have `libgcc_s.so`).

The ugly part of this patch is, of course, the `libgcc_s.so` hacks for LLVM-only systems. Since the bootstrap binary looks for `libgcc_s.so.1` (and therefore, dynamically linked), we need to work around this by fooling it using the good old `$LD_LIBRARY_PATH`. We also need to fool some parts since it looks for `-lgcc_s`, so we also add `libgcc_s.so` which only contains `INPUT(-lunwind)` so that `-lgcc_s` is more or less "aliased" to `-lunwind` and use `$LIBRARY_PATH` to fool `$CC`. (Surprisingly, the two unwinding functions between GCC and LLVM libunwind are compatible, though I can't say if this is an ABI compatibility or not).