### PR TITLE
firefox{,-beta}: enable nss build with Clang integrated assembler

### DIFF
--- a/extra/firefox-beta/build
+++ b/extra/firefox-beta/build
@@ -6,6 +6,15 @@ patch -p1 < no-x11.patch
 # URL is used.
 patch -p1 < attachment.cgi\?id=9202429
 
+# The most recent version of Clang is able to build NSS with its
+# integrated assembler.
+sed '/-no-integrated-as/d' security/nss/lib/freebl/Makefile > _
+mv -f _ security/nss/lib/freebl/Makefile
+sed '/-no-integrated-as/d' security/nss/lib/freebl/freebl.gyp > _
+mv -f _ security/nss/lib/freebl/freebl.gyp
+sed '/-no-integrated-as/d' security/nss/lib/freebl/freebl_base.gypi > _ 
+mv -f _ security/nss/lib/freebl/freebl_base.gypi
+
 # Remove fribidi dependency.
 sed '/fribidi/d' config/system-headers.mozbuild > _
 mv -f _ config/system-headers.mozbuild

--- a/extra/firefox/build
+++ b/extra/firefox/build
@@ -18,6 +18,15 @@ patch -p1 < no-x11.patch
 sed '/fribidi/d' config/system-headers.mozbuild > _
 mv -f _ config/system-headers.mozbuild
 
+# The most recent version of Clang is able to build NSS with its
+# integrated assembler.
+sed '/-no-integrated-as/d' security/nss/lib/freebl/Makefile > _
+mv -f _ security/nss/lib/freebl/Makefile
+sed '/-no-integrated-as/d' security/nss/lib/freebl/freebl.gyp > _
+mv -f _ security/nss/lib/freebl/freebl.gyp
+sed '/-no-integrated-as/d' security/nss/lib/freebl/freebl_base.gypi > _
+mv -f _ security/nss/lib/freebl/freebl_base.gypi
+
 # Remove libc header which conflicts with 7 or so Linux
 # kernel headers. See: https://github.com/kisslinux/repo/issues/207
 _f=dom/media/webrtc/transport/third_party/nICEr/src/stun/addrs-netlink.c


### PR DESCRIPTION
Since version 10.0 (or whatever version when Clang is able to build the kernel with using `LLVM_IAS=1`), the CFLAGS `-no-integrated-assembler` is not really needed anymore. We mainly use sed calls to remove the flags (like nodejs).