### PR TITLE
firefox: fix build with LLD

### DIFF
--- a/extra/firefox/build
+++ b/extra/firefox/build
@@ -9,10 +9,11 @@ patch -p1 < attachment.cgi\?id=9202429
 sed '/fribidi/d' config/system-headers.mozbuild > _
 mv -f _ config/system-headers.mozbuild
 
-# Remove libc header which conflicts with 7 or so Linux kernel headers.
+# Include net/if.h before linux/if.h since linux/if.h has redefinition
+# guards whereas net/if.h doesn't.
 # See: https://github.com/kisslinux/repo/issues/207
 _f=dom/media/webrtc/transport/third_party/nICEr/src/stun/addrs-netlink.c
-sed '/net\/if/d' "$_f" > _
+sed '/if defined(LINUX)/a#include <net\/if.h>' "$_f" > _
 mv -f _ "$_f"
 
 # The most recent version of Clang is able to build NSS with its integrated


### PR DESCRIPTION
With #207 still being an issue, removing `<net/if.h>` entirely is an option to solve the issue. However, doing this broke building Firefox with Clang/LLD (since `if_indextoname` exist in `<net/if.h>` but not `<linux/if.h>`). Adding `#include <net/if.h>` to the very beginning of the patch fixed it entirely for Clang (and probably GCC too since the patch existed in Void).

Logs:
```sh
46:08.01 security/nss/cmd/pk12util/pk12util
46:08.58 security/nss/cmd/shlibsign/shlibsign
46:36.00    Compiling webrender v0.61.0 (/home/koni/.cache/kiss/proc/3603/build/firefox/gfx/wr/webrender)
46:53.54    Compiling webrender_bindings v0.1.0 (/home/koni/.cache/kiss/proc/3603/build/firefox/gfx/webrender_bindings)
49:50.42    Compiling gkrust v0.1.0 (/home/koni/.cache/kiss/proc/3603/build/firefox/toolkit/library/rust)
54:26.72     Finished release [optimized] target(s) in 52m 36s
54:28.30 toolkit/library/build/libxul.so
54:34.45 ld: error: undefined hidden symbol: if_indextoname
54:34.45 >>> referenced by Unified_c_third_party_nICEr1.c
54:34.45 >>>               /home/koni/.cache/kiss/proc/3603/build/firefox/obj-x86_64-pc-linux-musl/toolkit/library/build/../../../dom/media/webrtc/transport/third_party/nICEr/nicer_nicer/Unified_c_third_party_nICEr1.o:(set_ifname)
54:34.64 clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
54:34.64 make[4]: *** [/home/koni/.cache/kiss/proc/3603/build/firefox/config/rules.mk:545: libxul.so] Error 1
54:34.64 make[3]: *** [/home/koni/.cache/kiss/proc/3603/build/firefox/config/recurse.mk:72: toolkit/library/build/target] Error 2
54:34.64 make[2]: *** [/home/koni/.cache/kiss/proc/3603/build/firefox/config/recurse.mk:34: compile] Error 2
54:34.64 make[1]: *** [/home/koni/.cache/kiss/proc/3603/build/firefox/config/rules.mk:355: default] Error 2
54:34.64 make: *** [client.mk:65: build] Error 2
```

Adapted from: https://github.com/void-linux/void-packages/blob/a77ef34692820b689b3854acd380077a0202a813/srcpkgs/firefox/patches/avoid-redefinition.patch