### PR TITLE
busybox: fix created acpid directory

### DIFF
--- a/core/busybox/build
+++ b/core/busybox/build
@@ -53,7 +53,7 @@ chmod u+s "$1/usr/bin/busybox-suid"
 
 # The acpid command requires that this directory exist
 # and does not automatically create it..
-mkdir -p "$1/etc/acpid"
+mkdir -p "$1/etc/acpi"
 
 # Install runit services.
 for s in acpid crond syslogd mdev ntpd; do


### PR DESCRIPTION
This is the correct directory for busybox acpid, and the one created when originally done so by the service file.